### PR TITLE
[#44] fix: fix hard-code name of conversation when create new

### DIFF
--- a/src/chat/ChatScreen.tsx
+++ b/src/chat/ChatScreen.tsx
@@ -114,24 +114,19 @@ export const ChatScreen: React.FC<ChatScreenProps> = ({
       /** If the conversation not created yet. it will create at the first message sent */
       isLoadingRef.current = false;
       if (!conversationRef.current?.id) {
-        const newConversationData = {
+        const newConversationInfo = {
           id: '',
           name: partners[0]?.name,
           image: partners[0]?.avatar,
+          ...(customConversationInfo || {}),
         };
-        let isGroup = false;
         // We identify a group chat if the conversation have custom-info
-        if (customConversationInfo) {
-          newConversationData.id = customConversationInfo.id;
-          newConversationData.name = customConversationInfo.name;
-          newConversationData.image = customConversationInfo.image;
-          isGroup = true;
-        }
+        let isGroup = !!customConversationInfo;
         conversationRef.current = await firebaseInstance.createConversation(
-          newConversationData.id,
+          newConversationInfo.id,
           memberIds,
-          newConversationData?.name,
-          newConversationData?.image,
+          newConversationInfo?.name,
+          newConversationInfo?.image,
           isGroup
         );
         firebaseInstance.setConversationInfo(

--- a/src/chat/ChatScreen.tsx
+++ b/src/chat/ChatScreen.tsx
@@ -114,11 +114,25 @@ export const ChatScreen: React.FC<ChatScreenProps> = ({
       /** If the conversation not created yet. it will create at the first message sent */
       isLoadingRef.current = false;
       if (!conversationRef.current?.id) {
+        const newConversationData = {
+          id: '',
+          name: partners[0]?.name,
+          image: partners[0]?.avatar,
+        };
+        let isGroup = false;
+        // We identify a group chat if the conversation have custom-info
+        if (customConversationInfo) {
+          newConversationData.id = customConversationInfo.id;
+          newConversationData.name = customConversationInfo.name;
+          newConversationData.image = customConversationInfo.image;
+          isGroup = true;
+        }
         conversationRef.current = await firebaseInstance.createConversation(
-          customConversationInfo?.id || '',
+          newConversationData.id,
           memberIds,
-          customConversationInfo?.name || partners[0]?.name,
-          customConversationInfo?.image || partners[0]?.avatar
+          newConversationData?.name,
+          newConversationData?.image,
+          isGroup
         );
         firebaseInstance.setConversationInfo(
           conversationRef.current?.id,

--- a/src/services/firebase/firestore.ts
+++ b/src/services/firebase/firestore.ts
@@ -104,7 +104,8 @@ export class FirestoreServices {
     conversationId: string,
     memberIds: string[],
     name?: string,
-    image?: string
+    image?: string,
+    isGroup?: boolean
   ): Promise<ConversationProps> => {
     let conversationData: Partial<ConversationProps> = {
       members: [this.userId, ...memberIds],
@@ -131,12 +132,23 @@ export class FirestoreServices {
     /** Add the conversation to the user who is conversation's member */
     await Promise.all([
       memberIds.map((memberId) => {
+        const otherMemberConversationData = isGroup
+          ? conversationData
+          : /**
+             * If this is 1-on-1 chat
+             * We map conversation info of other people with this user info
+             */
+            {
+              ...conversationData,
+              name: this.userInfo?.name,
+              image: this.userInfo?.avatar,
+            };
         return firestore()
           .collection(
             `${FireStoreCollection.users}/${memberId}/${FireStoreCollection.conversations}`
           )
           .doc(conversationRef.id)
-          .set(conversationData);
+          .set(otherMemberConversationData);
       }),
     ]);
 


### PR DESCRIPTION
Close #44 
This PR fix hard-code name of conversation when chat 1-on-1.

## Related issue
- #44 

## Demo
https://github.com/saigontechnology/rn-firebase-chat/assets/114563576/d8897023-f2fe-4e24-912f-46bb31426b47
