### PR TITLE
feat: allow to customize conversationItem by passing props to ListConversationScreen

### DIFF
--- a/src/chat/ListConversationScreen.tsx
+++ b/src/chat/ListConversationScreen.tsx
@@ -1,6 +1,9 @@
 import React, { useCallback, useMemo } from 'react';
 import { FlatList, StyleSheet, View } from 'react-native';
-import { ConversationItem } from './components/ConversationItem';
+import {
+  ConversationItem,
+  IConversationItemProps,
+} from './components/ConversationItem';
 import type { ConversationProps } from '../interfaces';
 import { useChatContext, useChatSelector } from '../hooks';
 import { setConversation } from '../reducer';
@@ -15,12 +18,14 @@ export interface IListConversationProps {
   hasSearchBar?: boolean;
   onPress?: (conversation: ConversationProps) => void;
   renderCustomItem?: ({ item, index }: ListItem) => JSX.Element | null;
+  conversationItemProps?: Omit<IConversationItemProps, 'data' | 'onPress'>; // remove default prop 'data' and 'onPress'
 }
 
 export const ListConversationScreen: React.FC<IListConversationProps> = ({
   // hasSearchBar,
   onPress,
   renderCustomItem,
+  conversationItemProps,
 }) => {
   const { chatDispatch } = useChatContext();
   const listConversation = useChatSelector(getListConversation);
@@ -42,10 +47,14 @@ export const ListConversationScreen: React.FC<IListConversationProps> = ({
     ({ item, index }: ListItem) => {
       if (renderCustomItem) return renderCustomItem({ item, index });
       return (
-        <ConversationItem data={item} onPress={handleConversationPressed} />
+        <ConversationItem
+          data={item}
+          onPress={handleConversationPressed}
+          {...(conversationItemProps || {})}
+        />
       );
     },
-    [handleConversationPressed, renderCustomItem]
+    [conversationItemProps, handleConversationPressed, renderCustomItem]
   );
 
   return (

--- a/src/chat/components/ConversationItem.tsx
+++ b/src/chat/components/ConversationItem.tsx
@@ -2,21 +2,16 @@
  * Created by NL on 01/07/21.
  */
 import React, { useMemo } from 'react';
-import {
-  Text,
-  StyleSheet,
-  View,
-  TouchableOpacity,
-  StyleProp,
-  TextStyle,
-  Image,
-} from 'react-native';
+import { Text, StyleSheet, View, TouchableOpacity, Image } from 'react-native';
+import type { StyleProp, TextStyle, ViewStyle } from 'react-native';
 import { MessageTypes, type ConversationProps } from '../../interfaces';
 import { randomColor } from '../../utilities';
 
 export interface IConversationItemProps {
   data: ConversationProps;
   onPress?: (_: ConversationProps) => void;
+  containerStyle?: StyleProp<ViewStyle>;
+  wrapperStyle?: StyleProp<ViewStyle>;
   titleStyle?: StyleProp<TextStyle>;
   lastMessageStyle?: StyleProp<TextStyle>;
   CustomImage?: typeof Image;
@@ -26,6 +21,8 @@ export interface IConversationItemProps {
 export const ConversationItem: React.FC<IConversationItemProps> = ({
   data,
   onPress,
+  containerStyle,
+  wrapperStyle,
   titleStyle,
   lastMessageStyle,
   CustomImage,
@@ -39,8 +36,11 @@ export const ConversationItem: React.FC<IConversationItemProps> = ({
   }, [data.image, data.name]);
 
   return (
-    <TouchableOpacity onPress={() => onPress?.(data)} style={styles.container}>
-      <View style={styles.row}>
+    <TouchableOpacity
+      onPress={() => onPress?.(data)}
+      style={[styles.container, StyleSheet.flatten(containerStyle)]}
+    >
+      <View style={[styles.row, StyleSheet.flatten(wrapperStyle)]}>
         <View style={styles.avatarContainer}>
           <View style={[styles.avatarWrapper, { backgroundColor }]}>
             {data.image ? (
@@ -54,10 +54,16 @@ export const ConversationItem: React.FC<IConversationItemProps> = ({
           renderMessage()
         ) : (
           <View style={styles.contentContainer}>
-            <Text style={[styles.title, titleStyle]} numberOfLines={1}>
+            <Text
+              style={[styles.title, StyleSheet.flatten(titleStyle)]}
+              numberOfLines={1}
+            >
               {data?.name}
             </Text>
-            <Text style={[styles.message, lastMessageStyle]} numberOfLines={1}>
+            <Text
+              style={[styles.message, StyleSheet.flatten(lastMessageStyle)]}
+              numberOfLines={1}
+            >
               {data?.latestMessage?.type === MessageTypes.text
                 ? data?.latestMessage?.text
                 : data?.latestMessage?.type === MessageTypes.image


### PR DESCRIPTION
- Adding `conversationItemProps` to `ListConversationScreen` component, to allow customize this item without having to use `renderCustomItem`