### PR TITLE
[#48] fix: reset conversation chat-state when exit ChatScreen

### DIFF
--- a/src/chat/ChatScreen.tsx
+++ b/src/chat/ChatScreen.tsx
@@ -35,6 +35,7 @@ import { CameraView, CameraViewRef } from '../chat_obs/components/CameraView';
 import SelectedImageModal from './components/SelectedImage';
 import { useCameraPermission } from 'react-native-vision-camera';
 import { CustomBubble, CustomImageVideoBubbleProps } from './components/bubble';
+import { clearConversation } from '../reducer';
 
 interface ChatScreenProps extends GiftedChatProps {
   style?: StyleProp<ViewStyle>;
@@ -64,7 +65,7 @@ export const ChatScreen: React.FC<ChatScreenProps> = ({
   customImageVideoBubbleProps,
   ...props
 }) => {
-  const { userInfo } = useChatContext();
+  const { userInfo, chatDispatch } = useChatContext();
   const conversation = useChatSelector(getConversation);
 
   const conversationInfo = useMemo(() => {
@@ -155,8 +156,9 @@ export const ChatScreen: React.FC<ChatScreenProps> = ({
   useEffect(() => {
     return () => {
       firebaseInstance.clearConversationInfo();
+      chatDispatch?.(clearConversation());
     };
-  }, [firebaseInstance]);
+  }, [chatDispatch, firebaseInstance]);
 
   useEffect(() => {
     let receiveMessageRef: () => void;

--- a/src/reducer/action.ts
+++ b/src/reducer/action.ts
@@ -3,6 +3,7 @@ import type { ConversationProps } from '../interfaces';
 export enum ChatActionKind {
   SET_LIST_CONVERSATION = 'SET_LIST_CONVERSATION',
   SET_CONVERSATION = 'SET_CONVERSATION',
+  CLEAR_CONVERSATION = 'CLEAR_CONVERSATION',
   UPDATE_CONVERSATION = 'UPDATE_CONVERSATION',
 }
 
@@ -14,6 +15,10 @@ export const setListConversation = (payload: ConversationProps[]) => ({
 export const setConversation = (payload: ConversationProps) => ({
   type: ChatActionKind.SET_CONVERSATION,
   payload,
+});
+
+export const clearConversation = () => ({
+  type: ChatActionKind.CLEAR_CONVERSATION,
 });
 
 export const updateConversation = (payload: ConversationProps) => ({

--- a/src/reducer/chat.ts
+++ b/src/reducer/chat.ts
@@ -3,7 +3,7 @@ import { ChatActionKind } from './action';
 
 export type ChatAction = {
   type: ChatActionKind;
-  payload: ConversationProps[] | ConversationProps;
+  payload?: ConversationProps[] | ConversationProps;
 };
 
 export type ChatState = {
@@ -25,6 +25,11 @@ export const chatReducer = (
       return {
         ...state,
         conversation: action.payload as ConversationProps,
+      };
+    case ChatActionKind.CLEAR_CONVERSATION:
+      return {
+        ...state,
+        conversation: undefined,
       };
     case ChatActionKind.UPDATE_CONVERSATION:
       const message = action.payload as ConversationProps;


### PR DESCRIPTION
Close #48 
Reset chat-state `conversation` data when exit `ChatScreen`

## Related issues:
- #44 

## Demo:
https://github.com/saigontechnology/rn-firebase-chat/assets/114563576/3d20514e-15d9-49be-9134-c46984ea43b7

